### PR TITLE
Add CELO network to deployment

### DIFF
--- a/ethereum/kycdao-ntnft/hardhat.config.ts
+++ b/ethereum/kycdao-ntnft/hardhat.config.ts
@@ -82,6 +82,20 @@ const config: HardhatUserConfig = {
         mnemonic: test_mnemonic(),
       },      
     },
+    alfajores: {
+      url: "https://alfajores-forno.celo-testnet.org",
+      accounts: {
+        mnemonic: test_mnemonic(),
+      },
+      chainId: 44787
+    },
+    celo: {
+      url: "https://forno.celo.org",
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+      chainId: 42220
+    },    
     fuji: {
       url: 'https://api.avax-test.network/ext/bc/C/rpc',
       accounts: {

--- a/ethereum/kycdao-ntnft/tasks/deploy.ts
+++ b/ethereum/kycdao-ntnft/tasks/deploy.ts
@@ -52,7 +52,7 @@ task("deploy", "Deploys the proxy and logic contract (using xdeploy) to a networ
             signer: privateKey,
             networks: [hre.network.name],
             rpcUrls: [networkConf.url],
-            gasLimit: 1.2 * 10 ** 6,
+            gasLimit: 12 * 10 ** 6,
         }
         console.log('\n\nDeploying proxy...')
         await setGasPriceIfReq(hre)


### PR DESCRIPTION
This adds support for contracts to be deployed to the CELO network (and it's Testnet: Alfajores).

NOTE: As there is no support for price feeds in the CELO network, we shouldn't deploy this yet. We'll need to also look at a change to support a price feed that's on CELO.