### PR TITLE
KYC-976 store safe address in contract

### DIFF
--- a/ethereum/kycdao-ntnft/CHANGELOG.md
+++ b/ethereum/kycdao-ntnft/CHANGELOG.md
@@ -8,6 +8,11 @@ NOTE: This CHANGELOG tracks changes to both contracts covered by kycDAO: **kycDA
 
 ## [Unreleased]
 
+## kycDAONTNFT [0.4.2] - 2023-03-07
+### Added
+- Added `safeAddress` variable to store multisig safe address, can be modified with the new `setSafeAddress` function
+- Renamed `sendBalanceTo` to `sendBalanceToSafe`, made it callable by anyone
+
 ## kycDAONTNFT [0.4.1] - 2022-12-20
 ### Added
 - Added a variable `storageVersion` which records the current version of the contract's stored variables, used when running `_migrate`

--- a/ethereum/kycdao-ntnft/CHANGELOG.md
+++ b/ethereum/kycdao-ntnft/CHANGELOG.md
@@ -8,10 +8,13 @@ NOTE: This CHANGELOG tracks changes to both contracts covered by kycDAO: **kycDA
 
 ## [Unreleased]
 
-## kycDAONTNFT [0.4.2] - 2023-03-07
+## kycDAONTNFT [0.4.3] - 2023-03-07
 ### Added
 - Added `safeAddress` variable to store multisig safe address, can be modified with the new `setSafeAddress` function
 - Renamed `sendBalanceTo` to `sendBalanceToSafe`, made it callable by anyone
+
+## kycDAONTNFT [0.4.2] - 2023-03-07
+- no changes in Solidity contract
 
 ## kycDAONTNFT [0.4.1] - 2022-12-20
 ### Added

--- a/ethereum/kycdao-ntnft/README.md
+++ b/ethereum/kycdao-ntnft/README.md
@@ -92,6 +92,9 @@ Keys used by the console for non-local chains will come from `test_mnemonic.txt`
 ## Retrieving balance from contract
 When users make payments to the contract these assets (such as MATIC) are stored in the Proxy contract itself.
 
-An address with the `OWNER` role can then run the following function to send the current balance of the contract to a specified address:
+An address with the `OWNER` role can set the safe address with the following function:
+`function setSafeAddress(address payable recipient_) public;`
 
-`function sendBalanceTo(address payable recipient_) public;`
+Then anyone can run the following function to send the current balance of the contract to the stored safe address:
+
+`function sendBalanceToSafe() public;`

--- a/ethereum/kycdao-ntnft/contracts/KycdaoNTNFT.sol
+++ b/ethereum/kycdao-ntnft/contracts/KycdaoNTNFT.sol
@@ -86,13 +86,19 @@ contract KycdaoNTNFT is ERC721EnumerableUpgradeable, AccessControlUpgradeable, B
     event StorageVersionUpdated(string newVersion);
 
     /*****************
+    START Version 0.4.2 VARIABLE DECLARATION
+    *****************/
+
+    address payable public safeAddress;
+
+    /*****************
     NOTICE: To ensure upgradeability, all NEW variables must be declared below.
     To keep track, ensure to add a version tracker to the start of the new variables declared
     *****************/
 
     /// @dev Current version of this smart contract
     function version() public pure returns (string memory) {
-        return "0.4.1";
+        return "0.4.2";
     }
 
     /// @dev This implementation contract shouldn't be initialized directly
@@ -365,8 +371,8 @@ contract KycdaoNTNFT is ERC721EnumerableUpgradeable, AccessControlUpgradeable, B
     }
 
     ///@dev for retrieving all payments sent to contract
-    function sendBalanceTo(address payable recipient_) public onlyOwner {
-        recipient_.transfer(address(this).balance);
+    function sendBalanceToSafe() public {
+        safeAddress.transfer(address(this).balance);
     }
 
     /*****************
@@ -394,6 +400,12 @@ contract KycdaoNTNFT is ERC721EnumerableUpgradeable, AccessControlUpgradeable, B
     /// @param address_ address the address of the price feed
     function setPriceFeed(address address_) external onlyOwner {
         nativeUSDPriceFeed = IPriceFeed(address_);
+    }
+
+    /// @notice Set the address of the multisig safe to send balance to
+    /// @param address_ address the address of the safe
+    function setSafeAddress(address payable address_) external onlyOwner {
+        safeAddress = address_;
     }
 
     /*****************

--- a/ethereum/kycdao-ntnft/contracts/KycdaoNTNFT.sol
+++ b/ethereum/kycdao-ntnft/contracts/KycdaoNTNFT.sol
@@ -86,7 +86,7 @@ contract KycdaoNTNFT is ERC721EnumerableUpgradeable, AccessControlUpgradeable, B
     event StorageVersionUpdated(string newVersion);
 
     /*****************
-    START Version 0.4.2 VARIABLE DECLARATION
+    START Version 0.4.3 VARIABLE DECLARATION
     *****************/
 
     address payable public safeAddress;
@@ -98,7 +98,7 @@ contract KycdaoNTNFT is ERC721EnumerableUpgradeable, AccessControlUpgradeable, B
 
     /// @dev Current version of this smart contract
     function version() public pure returns (string memory) {
-        return "0.4.2";
+        return "0.4.3";
     }
 
     /// @dev This implementation contract shouldn't be initialized directly
@@ -372,6 +372,7 @@ contract KycdaoNTNFT is ERC721EnumerableUpgradeable, AccessControlUpgradeable, B
 
     ///@dev for retrieving all payments sent to contract
     function sendBalanceToSafe() public {
+        require(safeAddress != address(0), "Safe address is not initialized!");
         safeAddress.transfer(address(this).balance);
     }
 

--- a/ethereum/kycdao-ntnft/test/KycdaoNTNFT.ts
+++ b/ethereum/kycdao-ntnft/test/KycdaoNTNFT.ts
@@ -14,7 +14,7 @@ import { BigNumber } from 'ethers'
 
 use(solidity)
 
-const expectedVersion = '0.4.1'
+const expectedVersion = '0.4.3'
 
 const zeroAddress = '0x0000000000000000000000000000000000000000'
 
@@ -663,14 +663,20 @@ describe.only('KycdaoNtnft Membership', function () {
     it('sends balance to an address given', async function () {
       await memberNftAsMinter.authorizeMintWithCode(456, anyone.address, testMetaUID, expiration, SECS_IN_YEAR, testTier)
       await memberNftAsAnyone.mintWithCode(456, {value: expectedMintCostOneYear})
-      const initialBal = await ethers.provider.getBalance(anyone.address)
-      await memberNftAsOwner.sendBalanceTo(anyone.address)
-      const finalBal = await ethers.provider.getBalance(anyone.address)
+      const initialBal = await ethers.provider.getBalance(receiver.address)
+      await memberNftAsOwner.setSafeAddress(receiver.address)
+      await memberNftAsAnyone.sendBalanceToSafe()
+      const finalBal = await ethers.provider.getBalance(receiver.address)
       expect(finalBal).to.equal(initialBal.add(expectedMintCostOneYear))
     })
 
     it('fails when not called by owner', async function () {
-      await expect(memberNftAsAnyone.sendBalanceTo(anyone.address)).to.be.revertedWith('!owner')
+      await expect(memberNftAsAnyone.setSafeAddress(anyone.address)).to.be.revertedWith('!owner')
+    })
+
+    it('fails when safe address is zero', async function () {
+      await memberNftAsOwner.setSafeAddress(zeroAddress)
+      await expect(memberNftAsAnyone.sendBalanceToSafe()).to.be.revertedWith('Safe address is not initialized!')
     })
     
   })

--- a/ethereum/kycdao-ntnft/test/KycdaoNTNFT_upgrade.ts
+++ b/ethereum/kycdao-ntnft/test/KycdaoNTNFT_upgrade.ts
@@ -15,7 +15,7 @@ import { BigNumber } from 'ethers'
 
 use(solidity)
 
-const expectedVersion = '0.4.1'
+const expectedVersion = '0.4.3'
 
 const zeroAddress = '0x0000000000000000000000000000000000000000'
 
@@ -734,14 +734,15 @@ describe.only('KycdaoNtnft Membership for an upgraded contract', function () {
     it('sends balance to an address given', async function () {
       await memberNftAsMinter.authorizeMintWithCode(456, anyone.address, testMetaUID, expiration, SECS_IN_YEAR, testTier)
       await memberNftAsAnyone.mintWithCode(456, {value: expectedMintCostOneYear})
-      const initialBal = await ethers.provider.getBalance(anyone.address)
-      await memberNftAsOwner.sendBalanceTo(anyone.address)
-      const finalBal = await ethers.provider.getBalance(anyone.address)
+      const initialBal = await ethers.provider.getBalance(receiver.address)
+      await memberNftAsOwner.setSafeAddress(receiver.address)
+      await memberNftAsAnyone.sendBalanceToSafe()
+      const finalBal = await ethers.provider.getBalance(receiver.address)
       expect(finalBal).to.equal(initialBal.add(expectedMintCostOneYear))
     })
 
     it('fails when not called by owner', async function () {
-      await expect(memberNftAsAnyone.sendBalanceTo(anyone.address)).to.be.revertedWith('!owner')
+      await expect(memberNftAsAnyone.setSafeAddress(anyone.address)).to.be.revertedWith('!owner')
     })
     
   })


### PR DESCRIPTION
- Added `safeAddress` variable to store multisig safe address, can be modified with the new `setSafeAddress` function
- Renamed `sendBalanceTo` to `sendBalanceToSafe`, made it callable by anyone